### PR TITLE
feat!: add new resource `aws_db_proxy_endpoint` for generating proxy endpoints from a dynamic map of inputs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.48.0
+    rev: v1.50.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 Terraform module which creates an AWS RDS Proxy and its supporting resources.
 
-The following resources are supported:
-
-- [AWS RDS Proxy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_proxy)
-- [AWS RDS Proxy Default Target Group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_proxy_default_target_group)
-- [AWS RDS Proxy Target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_proxy_target)
-
 ## Usage
 
 See [`examples`](./examples) directory for working examples to reference:
@@ -20,6 +14,20 @@ module "rds_proxy" {
   iam_role_name          = "rds-proxy-role"
   vpc_subnet_ids         = ["subnet-30ef7b3c", "subnet-1ecda77b", "subnet-ca09ddbc"]
   vpc_security_group_ids = ["sg-f1d03a88"]
+
+  db_proxy_endpoints = {
+    read_write = {
+      name                   = "read-write-endpoint"
+      vpc_subnet_ids         = ["subnet-30ef7b3c", "subnet-1ecda77b", "subnet-ca09ddbc"]
+      vpc_security_group_ids = ["sg-f1d03a88"]
+    },
+    read_only = {
+      name                   = "read-only-endpoint"
+      vpc_subnet_ids         = ["subnet-30ef7b3c", "subnet-1ecda77b", "subnet-ca09ddbc"]
+      vpc_security_group_ids = ["sg-f1d03a88"]
+      target_role            = "READ_ONLY"
+    }
+  }
 
   secrets = {
     "superuser" = {
@@ -58,14 +66,14 @@ Examples codified under the [`examples`](./examples) are intended to give users 
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.9 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.38 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.9 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.38 |
 
 ## Modules
 
@@ -78,6 +86,7 @@ No modules.
 | [aws_cloudwatch_log_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_db_proxy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_proxy) | resource |
 | [aws_db_proxy_default_target_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_proxy_default_target_group) | resource |
+| [aws_db_proxy_endpoint.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_proxy_endpoint) | resource |
 | [aws_db_proxy_target.db_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_proxy_target) | resource |
 | [aws_db_proxy_target.db_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_proxy_target) | resource |
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -100,6 +109,7 @@ No modules.
 | <a name="input_db_host"></a> [db\_host](#input\_db\_host) | The identifier to use for the database endpoint | `string` | `""` | no |
 | <a name="input_db_instance_identifier"></a> [db\_instance\_identifier](#input\_db\_instance\_identifier) | DB instance identifier | `string` | `""` | no |
 | <a name="input_db_name"></a> [db\_name](#input\_db\_name) | The name of the database | `string` | `""` | no |
+| <a name="input_db_proxy_endpoints"></a> [db\_proxy\_endpoints](#input\_db\_proxy\_endpoints) | Map of DB proxy endpoints to create and their attributes (see `aws_db_proxy_endpoint`) | `any` | `{}` | no |
 | <a name="input_debug_logging"></a> [debug\_logging](#input\_debug\_logging) | Whether the proxy includes detailed information about SQL statements in its logs | `bool` | `false` | no |
 | <a name="input_engine_family"></a> [engine\_family](#input\_engine\_family) | The kind of database engine that the proxy will connect to. Valid values are `MYSQL` or `POSTGRESQL` | `string` | `""` | no |
 | <a name="input_iam_auth"></a> [iam\_auth](#input\_iam\_auth) | Whether to require or disallow AWS Identity and Access Management (IAM) authentication for connections to the proxy. One of `DISABLED`, `REQUIRED` | `string` | `"REQUIRED"` | no |
@@ -138,6 +148,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_db_proxy_endpoints"></a> [db\_proxy\_endpoints](#output\_db\_proxy\_endpoints) | Array containing the full resource object and attributes for all DB proxy endpoints created |
 | <a name="output_log_group_arn"></a> [log\_group\_arn](#output\_log\_group\_arn) | The Amazon Resource Name (ARN) of the CloudWatch log group |
 | <a name="output_proxy_arn"></a> [proxy\_arn](#output\_proxy\_arn) | The Amazon Resource Name (ARN) for the proxy |
 | <a name="output_proxy_default_target_group_arn"></a> [proxy\_default\_target\_group\_arn](#output\_proxy\_default\_target\_group\_arn) | The Amazon Resource Name (ARN) for the default target group |

--- a/examples/mysql_iam_cluster/README.md
+++ b/examples/mysql_iam_cluster/README.md
@@ -30,26 +30,26 @@ An EC2 instance configuration has been provided for use in validating the exampl
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.9 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.38 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.9 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.38 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ec2_instance"></a> [ec2\_instance](#module\_ec2\_instance) | terraform-aws-modules/ec2-instance/aws | 2.16.0 |
-| <a name="module_ec2_sg"></a> [ec2\_sg](#module\_ec2\_sg) | terraform-aws-modules/security-group/aws | 3.17.0 |
-| <a name="module_rds"></a> [rds](#module\_rds) | terraform-aws-modules/rds-aurora/aws | 3.0.0 |
+| <a name="module_ec2_instance"></a> [ec2\_instance](#module\_ec2\_instance) | terraform-aws-modules/ec2-instance/aws | ~> 2 |
+| <a name="module_ec2_sg"></a> [ec2\_sg](#module\_ec2\_sg) | terraform-aws-modules/security-group/aws | ~> 4 |
+| <a name="module_rds"></a> [rds](#module\_rds) | terraform-aws-modules/rds-aurora/aws | ~> 4 |
 | <a name="module_rds_proxy"></a> [rds\_proxy](#module\_rds\_proxy) | ../../ |  |
-| <a name="module_rds_proxy_sg"></a> [rds\_proxy\_sg](#module\_rds\_proxy\_sg) | terraform-aws-modules/security-group/aws | 3.17.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 2.64.0 |
+| <a name="module_rds_proxy_sg"></a> [rds\_proxy\_sg](#module\_rds\_proxy\_sg) | terraform-aws-modules/security-group/aws | ~> 4 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3 |
 
 ## Resources
 
@@ -80,6 +80,7 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_db_proxy_endpoints"></a> [db\_proxy\_endpoints](#output\_db\_proxy\_endpoints) | Array containing the full resource object and attributes for all DB proxy endpoints created |
 | <a name="output_log_group_arn"></a> [log\_group\_arn](#output\_log\_group\_arn) | The Amazon Resource Name (ARN) of the CloudWatch log group |
 | <a name="output_proxy_arn"></a> [proxy\_arn](#output\_proxy\_arn) | The Amazon Resource Name (ARN) for the proxy |
 | <a name="output_proxy_default_target_group_arn"></a> [proxy\_default\_target\_group\_arn](#output\_proxy\_default\_target\_group\_arn) | The Amazon Resource Name (ARN) for the default target group |

--- a/examples/mysql_iam_cluster/outputs.tf
+++ b/examples/mysql_iam_cluster/outputs.tf
@@ -66,6 +66,12 @@ output "proxy_target_type" {
   value       = module.rds_proxy.proxy_target_type
 }
 
+# DB proxy endponts
+output "db_proxy_endpoints" {
+  description = "Array containing the full resource object and attributes for all DB proxy endpoints created"
+  value       = module.rds_proxy.db_proxy_endpoints
+}
+
 # CloudWatch logs
 output "log_group_arn" {
   description = "The Amazon Resource Name (ARN) of the CloudWatch log group"
@@ -75,7 +81,8 @@ output "log_group_arn" {
 # For aiding in testing & verification
 output "superuser_db_password_connect" {
   description = "Connect to database using superuser with username/password directly to database"
-  value       = "mysql --host=${module.rds.this_rds_cluster_endpoint} --user=${local.db_username} --password=${local.db_password} ${module.rds.this_rds_cluster_database_name}"
+  value       = "mysql --host=${module.rds.rds_cluster_endpoint} --user=${local.db_username} --password=${local.db_password} ${module.rds.rds_cluster_database_name}"
+  sensitive   = true
 }
 
 output "superuser_proxy_iam_token" {
@@ -85,5 +92,5 @@ output "superuser_proxy_iam_token" {
 
 output "superuser_proxy_iam_connect" {
   description = "Connect to RDS Proxy using IAM auth via token generated"
-  value       = "mysql --host=${module.rds_proxy.proxy_endpoint} --user=${local.db_username} --password=$TOKEN ${module.rds.this_rds_cluster_database_name} --ssl-ca=/home/ssm-user/AmazonRootCA1.pem --enable-cleartext-plugin"
+  value       = "mysql --host=${module.rds_proxy.proxy_endpoint} --user=${local.db_username} --password=$TOKEN ${module.rds.rds_cluster_database_name} --ssl-ca=/home/ssm-user/AmazonRootCA1.pem --enable-cleartext-plugin"
 }

--- a/examples/mysql_iam_cluster/versions.tf
+++ b/examples/mysql_iam_cluster/versions.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13.1"
 
   required_providers {
-    aws = ">= 3.9"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.38"
+    }
   }
 }

--- a/examples/mysql_iam_instance/README.md
+++ b/examples/mysql_iam_instance/README.md
@@ -30,27 +30,27 @@ An EC2 instance configuration has been provided for use in validating the exampl
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.9 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.38 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.9 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.38 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ec2_instance"></a> [ec2\_instance](#module\_ec2\_instance) | terraform-aws-modules/ec2-instance/aws | 2.16.0 |
-| <a name="module_ec2_sg"></a> [ec2\_sg](#module\_ec2\_sg) | terraform-aws-modules/security-group/aws | 3.17.0 |
-| <a name="module_rds"></a> [rds](#module\_rds) | terraform-aws-modules/rds/aws | 2.20.0 |
+| <a name="module_ec2_instance"></a> [ec2\_instance](#module\_ec2\_instance) | terraform-aws-modules/ec2-instance/aws | ~> 2 |
+| <a name="module_ec2_sg"></a> [ec2\_sg](#module\_ec2\_sg) | terraform-aws-modules/security-group/aws | ~> 4 |
+| <a name="module_rds"></a> [rds](#module\_rds) | terraform-aws-modules/rds/aws | ~> 3 |
 | <a name="module_rds_proxy"></a> [rds\_proxy](#module\_rds\_proxy) | ../../ |  |
-| <a name="module_rds_proxy_sg"></a> [rds\_proxy\_sg](#module\_rds\_proxy\_sg) | terraform-aws-modules/security-group/aws | 3.17.0 |
-| <a name="module_rds_sg"></a> [rds\_sg](#module\_rds\_sg) | terraform-aws-modules/security-group/aws | 3.17.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 2.64.0 |
+| <a name="module_rds_proxy_sg"></a> [rds\_proxy\_sg](#module\_rds\_proxy\_sg) | terraform-aws-modules/security-group/aws | ~> 4 |
+| <a name="module_rds_sg"></a> [rds\_sg](#module\_rds\_sg) | terraform-aws-modules/security-group/aws | ~> 4 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3 |
 
 ## Resources
 
@@ -79,6 +79,7 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_db_proxy_endpoints"></a> [db\_proxy\_endpoints](#output\_db\_proxy\_endpoints) | Array containing the full resource object and attributes for all DB proxy endpoints created |
 | <a name="output_log_group_arn"></a> [log\_group\_arn](#output\_log\_group\_arn) | The Amazon Resource Name (ARN) of the CloudWatch log group |
 | <a name="output_proxy_arn"></a> [proxy\_arn](#output\_proxy\_arn) | The Amazon Resource Name (ARN) for the proxy |
 | <a name="output_proxy_default_target_group_arn"></a> [proxy\_default\_target\_group\_arn](#output\_proxy\_default\_target\_group\_arn) | The Amazon Resource Name (ARN) for the default target group |

--- a/examples/mysql_iam_instance/outputs.tf
+++ b/examples/mysql_iam_instance/outputs.tf
@@ -66,6 +66,12 @@ output "proxy_target_type" {
   value       = module.rds_proxy.proxy_target_type
 }
 
+# DB proxy endponts
+output "db_proxy_endpoints" {
+  description = "Array containing the full resource object and attributes for all DB proxy endpoints created"
+  value       = module.rds_proxy.db_proxy_endpoints
+}
+
 # CloudWatch logs
 output "log_group_arn" {
   description = "The Amazon Resource Name (ARN) of the CloudWatch log group"
@@ -75,7 +81,8 @@ output "log_group_arn" {
 # For aiding in testing & verification
 output "superuser_db_password_connect" {
   description = "Connect to database using superuser with username/password directly to database"
-  value       = "mysql --host=${module.rds.this_db_instance_address} --user=${local.db_username} --password=${local.db_password} ${module.rds.this_db_instance_name}"
+  value       = "mysql --host=${module.rds.db_instance_address} --user=${local.db_username} --password=${local.db_password} ${module.rds.db_instance_name}"
+  sensitive   = true
 }
 
 output "superuser_proxy_iam_token" {
@@ -85,5 +92,5 @@ output "superuser_proxy_iam_token" {
 
 output "superuser_proxy_iam_connect" {
   description = "Connect to RDS Proxy using IAM auth via token generated"
-  value       = "mysql --host=${module.rds_proxy.proxy_endpoint} --user=${local.db_username} --password=$TOKEN ${module.rds.this_db_instance_name} --ssl-ca=/home/ssm-user/AmazonRootCA1.pem --enable-cleartext-plugin"
+  value       = "mysql --host=${module.rds_proxy.proxy_endpoint} --user=${local.db_username} --password=$TOKEN ${module.rds.db_instance_name} --ssl-ca=/home/ssm-user/AmazonRootCA1.pem --enable-cleartext-plugin"
 }

--- a/examples/mysql_iam_instance/versions.tf
+++ b/examples/mysql_iam_instance/versions.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13.1"
 
   required_providers {
-    aws = ">= 3.9"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.38"
+    }
   }
 }

--- a/examples/postgresql_iam_cluster/README.md
+++ b/examples/postgresql_iam_cluster/README.md
@@ -30,26 +30,26 @@ An EC2 instance configuration has been provided for use in validating the exampl
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.9 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.38 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.9 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.38 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ec2_instance"></a> [ec2\_instance](#module\_ec2\_instance) | terraform-aws-modules/ec2-instance/aws | 2.16.0 |
-| <a name="module_ec2_sg"></a> [ec2\_sg](#module\_ec2\_sg) | terraform-aws-modules/security-group/aws | 3.17.0 |
-| <a name="module_rds"></a> [rds](#module\_rds) | terraform-aws-modules/rds-aurora/aws | 3.0.0 |
+| <a name="module_ec2_instance"></a> [ec2\_instance](#module\_ec2\_instance) | terraform-aws-modules/ec2-instance/aws | ~> 2 |
+| <a name="module_ec2_sg"></a> [ec2\_sg](#module\_ec2\_sg) | terraform-aws-modules/security-group/aws | ~> 4 |
+| <a name="module_rds"></a> [rds](#module\_rds) | terraform-aws-modules/rds-aurora/aws | ~> 5 |
 | <a name="module_rds_proxy"></a> [rds\_proxy](#module\_rds\_proxy) | ../../ |  |
-| <a name="module_rds_proxy_sg"></a> [rds\_proxy\_sg](#module\_rds\_proxy\_sg) | terraform-aws-modules/security-group/aws | 3.17.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 2.64.0 |
+| <a name="module_rds_proxy_sg"></a> [rds\_proxy\_sg](#module\_rds\_proxy\_sg) | terraform-aws-modules/security-group/aws | ~> 4 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3 |
 
 ## Resources
 
@@ -80,6 +80,7 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_db_proxy_endpoints"></a> [db\_proxy\_endpoints](#output\_db\_proxy\_endpoints) | Array containing the full resource object and attributes for all DB proxy endpoints created |
 | <a name="output_log_group_arn"></a> [log\_group\_arn](#output\_log\_group\_arn) | The Amazon Resource Name (ARN) of the CloudWatch log group |
 | <a name="output_proxy_arn"></a> [proxy\_arn](#output\_proxy\_arn) | The Amazon Resource Name (ARN) for the proxy |
 | <a name="output_proxy_default_target_group_arn"></a> [proxy\_default\_target\_group\_arn](#output\_proxy\_default\_target\_group\_arn) | The Amazon Resource Name (ARN) for the default target group |

--- a/examples/postgresql_iam_cluster/main.tf
+++ b/examples/postgresql_iam_cluster/main.tf
@@ -38,7 +38,7 @@ resource "random_password" "password" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.64.0"
+  version = "~> 3"
 
   name = local.name
   cidr = "10.0.0.0/18"
@@ -57,7 +57,7 @@ module "vpc" {
 
 module "rds" {
   source  = "terraform-aws-modules/rds-aurora/aws"
-  version = "3.0.0"
+  version = "~> 5"
 
   name          = local.name
   database_name = local.db_name
@@ -77,7 +77,7 @@ module "rds" {
 
   vpc_id                  = module.vpc.vpc_id
   subnets                 = module.vpc.database_subnets
-  allowed_security_groups = [module.rds_proxy_sg.this_security_group_id]
+  allowed_security_groups = [module.rds_proxy_sg.security_group_id]
 
   db_subnet_group_name            = local.name # Created by VPC module
   db_parameter_group_name         = aws_db_parameter_group.aurora_db_postgres11_parameter_group.id
@@ -158,7 +158,7 @@ data "aws_ami" "ubuntu" {
 
 module "ec2_sg" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "3.17.0"
+  version = "~> 4"
 
   name        = "ec2"
   description = "EC2 RDS Proxy example security group"
@@ -171,7 +171,7 @@ module "ec2_sg" {
 
 module "ec2_instance" {
   source  = "terraform-aws-modules/ec2-instance/aws"
-  version = "2.16.0"
+  version = "~> 2"
 
   name           = local.name
   instance_count = 1
@@ -190,7 +190,7 @@ module "ec2_instance" {
 
   ami                    = data.aws_ami.ubuntu.id
   instance_type          = "t3.micro"
-  vpc_security_group_ids = [module.ec2_sg.this_security_group_id]
+  vpc_security_group_ids = [module.ec2_sg.security_group_id]
   subnet_ids             = module.vpc.private_subnets
 
   tags = local.tags
@@ -226,7 +226,7 @@ resource "aws_secretsmanager_secret_version" "superuser" {
 
 module "rds_proxy_sg" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "3.17.0"
+  version = "~> 4"
 
   name        = "rds_proxy"
   description = "PostgreSQL RDS Proxy example security group"
@@ -261,7 +261,23 @@ module "rds_proxy" {
   name                   = local.name
   iam_role_name          = local.name
   vpc_subnet_ids         = module.vpc.private_subnets
-  vpc_security_group_ids = [module.rds_proxy_sg.this_security_group_id]
+  vpc_security_group_ids = [module.rds_proxy_sg.security_group_id]
+
+  db_proxy_endpoints = {
+    read_write = {
+      name                   = "read-write-endpoint"
+      vpc_subnet_ids         = module.vpc.private_subnets
+      vpc_security_group_ids = [module.rds_proxy_sg.security_group_id]
+      tags                   = local.tags
+    },
+    read_only = {
+      name                   = "read-only-endpoint"
+      vpc_subnet_ids         = module.vpc.private_subnets
+      vpc_security_group_ids = [module.rds_proxy_sg.security_group_id]
+      target_role            = "READ_ONLY"
+      tags                   = local.tags
+    }
+  }
 
   secrets = {
     "${local.db_username}" = {
@@ -272,13 +288,13 @@ module "rds_proxy" {
   }
 
   engine_family = "POSTGRESQL"
-  db_host       = module.rds.this_rds_cluster_endpoint
-  db_name       = module.rds.this_rds_cluster_database_name
+  db_host       = module.rds.rds_cluster_endpoint
+  db_name       = module.rds.rds_cluster_database_name
   debug_logging = true
 
   # Target Aurora cluster
   target_db_cluster     = true
-  db_cluster_identifier = module.rds.this_rds_cluster_id
+  db_cluster_identifier = module.rds.rds_cluster_id
 
   tags = local.tags
 }

--- a/examples/postgresql_iam_cluster/outputs.tf
+++ b/examples/postgresql_iam_cluster/outputs.tf
@@ -66,6 +66,12 @@ output "proxy_target_type" {
   value       = module.rds_proxy.proxy_target_type
 }
 
+# DB proxy endponts
+output "db_proxy_endpoints" {
+  description = "Array containing the full resource object and attributes for all DB proxy endpoints created"
+  value       = module.rds_proxy.db_proxy_endpoints
+}
+
 # CloudWatch logs
 output "log_group_arn" {
   description = "The Amazon Resource Name (ARN) of the CloudWatch log group"
@@ -75,7 +81,8 @@ output "log_group_arn" {
 # For aiding in testing & verification
 output "superuser_db_password_connect" {
   description = "Connect to database using superuser with username/password directly to database"
-  value       = "PGPASSWORD=${local.db_password} psql -h ${module.rds.this_rds_cluster_endpoint} -p 5432 -d ${module.rds.this_rds_cluster_database_name} -U ${local.db_username} --set=sslmode=require"
+  value       = "PGPASSWORD=${local.db_password} psql -h ${module.rds.rds_cluster_endpoint} -p 5432 -d ${module.rds.rds_cluster_database_name} -U ${local.db_username} --set=sslmode=require"
+  sensitive   = true
 }
 
 output "superuser_proxy_iam_token" {
@@ -85,5 +92,5 @@ output "superuser_proxy_iam_token" {
 
 output "superuser_proxy_iam_connect" {
   description = "Connect to RDS Proxy using IAM auth via token generated"
-  value       = "psql \"host=${module.rds_proxy.proxy_endpoint} port=5432 sslmode=verify-full sslrootcert=/home/ssm-user/AmazonRootCA1.pem dbname=${module.rds.this_rds_cluster_database_name} user=${local.db_username} password=$TOKEN\""
+  value       = "psql \"host=${module.rds_proxy.proxy_endpoint} port=5432 sslmode=verify-full sslrootcert=/home/ssm-user/AmazonRootCA1.pem dbname=${module.rds.rds_cluster_database_name} user=${local.db_username} password=$TOKEN\""
 }

--- a/examples/postgresql_iam_cluster/versions.tf
+++ b/examples/postgresql_iam_cluster/versions.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13.1"
 
   required_providers {
-    aws = ">= 3.9"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.38"
+    }
   }
 }

--- a/examples/postgresql_iam_instance/README.md
+++ b/examples/postgresql_iam_instance/README.md
@@ -30,27 +30,27 @@ An EC2 instance configuration has been provided for use in validating the exampl
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.26 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.9 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.38 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.9 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.38 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ec2_instance"></a> [ec2\_instance](#module\_ec2\_instance) | terraform-aws-modules/ec2-instance/aws | 2.16.0 |
-| <a name="module_ec2_sg"></a> [ec2\_sg](#module\_ec2\_sg) | terraform-aws-modules/security-group/aws | 3.17.0 |
-| <a name="module_rds"></a> [rds](#module\_rds) | terraform-aws-modules/rds/aws | 2.20.0 |
+| <a name="module_ec2_instance"></a> [ec2\_instance](#module\_ec2\_instance) | terraform-aws-modules/ec2-instance/aws | ~> 2 |
+| <a name="module_ec2_sg"></a> [ec2\_sg](#module\_ec2\_sg) | terraform-aws-modules/security-group/aws | ~> 4 |
+| <a name="module_rds"></a> [rds](#module\_rds) | terraform-aws-modules/rds/aws | ~> 3 |
 | <a name="module_rds_proxy"></a> [rds\_proxy](#module\_rds\_proxy) | ../../ |  |
-| <a name="module_rds_proxy_sg"></a> [rds\_proxy\_sg](#module\_rds\_proxy\_sg) | terraform-aws-modules/security-group/aws | 3.17.0 |
-| <a name="module_rds_sg"></a> [rds\_sg](#module\_rds\_sg) | terraform-aws-modules/security-group/aws | 3.17.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 2.64.0 |
+| <a name="module_rds_proxy_sg"></a> [rds\_proxy\_sg](#module\_rds\_proxy\_sg) | terraform-aws-modules/security-group/aws | ~> 4 |
+| <a name="module_rds_sg"></a> [rds\_sg](#module\_rds\_sg) | terraform-aws-modules/security-group/aws | ~> 4 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3 |
 
 ## Resources
 
@@ -79,6 +79,7 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_db_proxy_endpoints"></a> [db\_proxy\_endpoints](#output\_db\_proxy\_endpoints) | Array containing the full resource object and attributes for all DB proxy endpoints created |
 | <a name="output_log_group_arn"></a> [log\_group\_arn](#output\_log\_group\_arn) | The Amazon Resource Name (ARN) of the CloudWatch log group |
 | <a name="output_proxy_arn"></a> [proxy\_arn](#output\_proxy\_arn) | The Amazon Resource Name (ARN) for the proxy |
 | <a name="output_proxy_default_target_group_arn"></a> [proxy\_default\_target\_group\_arn](#output\_proxy\_default\_target\_group\_arn) | The Amazon Resource Name (ARN) for the default target group |

--- a/examples/postgresql_iam_instance/main.tf
+++ b/examples/postgresql_iam_instance/main.tf
@@ -38,7 +38,7 @@ resource "random_password" "password" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "2.64.0"
+  version = "~> 3"
 
   name = local.name
   cidr = "10.0.0.0/18"
@@ -56,7 +56,7 @@ module "vpc" {
 
 module "rds_sg" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "3.17.0"
+  version = "~> 4"
 
   name        = "rds"
   description = "PostgreSQL RDS example security group"
@@ -77,7 +77,7 @@ module "rds_sg" {
 
 module "rds" {
   source  = "terraform-aws-modules/rds/aws"
-  version = "2.20.0"
+  version = "~> 3"
 
   name     = local.db_name
   username = local.db_username
@@ -97,7 +97,7 @@ module "rds" {
   storage_encrypted    = false
   apply_immediately    = true
 
-  vpc_security_group_ids = [module.rds_sg.this_security_group_id]
+  vpc_security_group_ids = [module.rds_sg.security_group_id]
   subnet_ids             = module.vpc.database_subnets
 
   maintenance_window      = "Mon:00:00-Mon:03:00"
@@ -168,7 +168,7 @@ data "aws_ami" "ubuntu" {
 
 module "ec2_sg" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "3.17.0"
+  version = "~> 4"
 
   name        = "ec2"
   description = "EC2 RDS Proxy example security group"
@@ -181,7 +181,7 @@ module "ec2_sg" {
 
 module "ec2_instance" {
   source  = "terraform-aws-modules/ec2-instance/aws"
-  version = "2.16.0"
+  version = "~> 2"
 
   name           = local.name
   instance_count = 1
@@ -200,7 +200,7 @@ module "ec2_instance" {
 
   ami                    = data.aws_ami.ubuntu.id
   instance_type          = "t3.micro"
-  vpc_security_group_ids = [module.ec2_sg.this_security_group_id]
+  vpc_security_group_ids = [module.ec2_sg.security_group_id]
   subnet_ids             = module.vpc.private_subnets
 
   tags = local.tags
@@ -236,7 +236,7 @@ resource "aws_secretsmanager_secret_version" "superuser" {
 
 module "rds_proxy_sg" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "3.17.0"
+  version = "~> 4"
 
   name        = "rds_proxy"
   description = "PostgreSQL RDS Proxy example security group"
@@ -271,7 +271,23 @@ module "rds_proxy" {
   name                   = local.name
   iam_role_name          = local.name
   vpc_subnet_ids         = module.vpc.private_subnets
-  vpc_security_group_ids = [module.rds_proxy_sg.this_security_group_id]
+  vpc_security_group_ids = [module.rds_proxy_sg.security_group_id]
+
+  db_proxy_endpoints = {
+    read_write = {
+      name                   = "read-write-endpoint"
+      vpc_subnet_ids         = module.vpc.private_subnets
+      vpc_security_group_ids = [module.rds_proxy_sg.security_group_id]
+      tags                   = local.tags
+    },
+    read_only = {
+      name                   = "read-only-endpoint"
+      vpc_subnet_ids         = module.vpc.private_subnets
+      vpc_security_group_ids = [module.rds_proxy_sg.security_group_id]
+      target_role            = "READ_ONLY"
+      tags                   = local.tags
+    }
+  }
 
   secrets = {
     "${local.db_username}" = {
@@ -282,13 +298,13 @@ module "rds_proxy" {
   }
 
   engine_family = "POSTGRESQL"
-  db_host       = module.rds.this_db_instance_address
-  db_name       = module.rds.this_db_instance_name
+  db_host       = module.rds.db_instance_address
+  db_name       = module.rds.db_instance_name
   debug_logging = true
 
   # Target RDS instance
   target_db_instance     = true
-  db_instance_identifier = module.rds.this_db_instance_id
+  db_instance_identifier = module.rds.db_instance_id
 
   tags = local.tags
 }

--- a/examples/postgresql_iam_instance/outputs.tf
+++ b/examples/postgresql_iam_instance/outputs.tf
@@ -66,6 +66,12 @@ output "proxy_target_type" {
   value       = module.rds_proxy.proxy_target_type
 }
 
+# DB proxy endponts
+output "db_proxy_endpoints" {
+  description = "Array containing the full resource object and attributes for all DB proxy endpoints created"
+  value       = module.rds_proxy.db_proxy_endpoints
+}
+
 # CloudWatch logs
 output "log_group_arn" {
   description = "The Amazon Resource Name (ARN) of the CloudWatch log group"
@@ -75,7 +81,8 @@ output "log_group_arn" {
 # For aiding in testing & verification
 output "superuser_db_password_connect" {
   description = "Connect to database using superuser with username/password directly to database"
-  value       = "PGPASSWORD=${local.db_password} psql -h ${module.rds.this_db_instance_address} -p 5432 -d ${module.rds.this_db_instance_name} -U ${local.db_username} --set=sslmode=require"
+  value       = "PGPASSWORD=${local.db_password} psql -h ${module.rds.db_instance_address} -p 5432 -d ${module.rds.db_instance_name} -U ${local.db_username} --set=sslmode=require"
+  sensitive   = true
 }
 
 output "superuser_proxy_iam_token" {
@@ -85,5 +92,5 @@ output "superuser_proxy_iam_token" {
 
 output "superuser_proxy_iam_connect" {
   description = "Connect to RDS Proxy using IAM auth via token generated"
-  value       = "psql \"host=${module.rds_proxy.proxy_endpoint} port=5432 sslmode=verify-full sslrootcert=/home/ssm-user/AmazonRootCA1.pem dbname=${module.rds.this_db_instance_name} user=${local.db_username} password=$TOKEN\""
+  value       = "psql \"host=${module.rds_proxy.proxy_endpoint} port=5432 sslmode=verify-full sslrootcert=/home/ssm-user/AmazonRootCA1.pem dbname=${module.rds.db_instance_name} user=${local.db_username} password=$TOKEN\""
 }

--- a/examples/postgresql_iam_instance/versions.tf
+++ b/examples/postgresql_iam_instance/versions.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13.1"
 
   required_providers {
-    aws = ">= 3.9"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.38"
+    }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -70,6 +70,18 @@ resource "aws_db_proxy_target" "db_cluster" {
   db_cluster_identifier = var.db_cluster_identifier
 }
 
+resource "aws_db_proxy_endpoint" "this" {
+  for_each = var.db_proxy_endpoints
+
+  db_proxy_name          = aws_db_proxy.this[0].name
+  db_proxy_endpoint_name = each.value.name
+  vpc_subnet_ids         = each.value.vpc_subnet_ids
+  vpc_security_group_ids = lookup(each.value, "vpc_security_group_ids", null)
+  target_role            = lookup(each.value, "target_role", null)
+
+  tags = lookup(each.value, "tags", var.tags)
+}
+
 ################################################################################
 # CloudWatch Logs
 ################################################################################

--- a/outputs.tf
+++ b/outputs.tf
@@ -66,6 +66,12 @@ output "proxy_target_type" {
   value       = element(concat(aws_db_proxy_target.db_instance.*.type, aws_db_proxy_target.db_cluster.*.type, [""]), 0)
 }
 
+# DB proxy endponts
+output "db_proxy_endpoints" {
+  description = "Array containing the full resource object and attributes for all DB proxy endpoints created"
+  value       = aws_db_proxy_endpoint.this
+}
+
 # CloudWatch logs
 output "log_group_arn" {
   description = "The Amazon Resource Name (ARN) of the CloudWatch log group"

--- a/variables.tf
+++ b/variables.tf
@@ -157,6 +157,13 @@ variable "db_cluster_identifier" {
   default     = ""
 }
 
+# Proxy endpoints
+variable "db_proxy_endpoints" {
+  description = "Map of DB proxy endpoints to create and their attributes (see `aws_db_proxy_endpoint`)"
+  type        = any
+  default     = {}
+}
+
 # CloudWatch Logs
 variable "manage_log_group" {
   description = "Determines whether Terraform will create/manage the CloudWatch log group or not. Note - this will fail if set to true after the log group has been created as the resource will already exist"

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,10 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13.1"
 
   required_providers {
-    aws = ">= 3.9"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.38"
+    }
   }
 }


### PR DESCRIPTION
## Description
- add new resource `aws_db_proxy_endpoint` for generating proxy endpoints from a dynamic map of inputs
- upgrade minimum version of Terraform to 0.13.1
- upgrade minimum version of AWS provider to support new resource

## Motivation and Context
- Closes #4

## How Has This Been Tested?
- tested with both PostgreSQL cluster and instance examples

## Screenshots (if appropriate):
